### PR TITLE
Fix catch receiving wrapped Exceptions.

### DIFF
--- a/lib/galaxy.js
+++ b/lib/galaxy.js
@@ -396,7 +396,7 @@
 	}
 
 	function wrapError(err, g, resume) {
-		if (typeof err !== 'object') return err; // handle throw "some string";
+		if (!(err instanceof Error)) return err; // handle throw "some string";
 		if (err.__async__ && err.__async__.resume === resume) return err;
 		var continuations = [];
 		g = g.prev; // first frame will be in err.stack


### PR DESCRIPTION
The wrapped exceptions will print out "{}" with util.inspect,
which is misleading.

Fix #6
